### PR TITLE
Feature: PortOneClient 액세스 토큰 캐싱 로직 적용 및 테스트 보강

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,16 @@ dependencies {
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Mockito + JUnit 5 통합 (MockitoExtension 사용 시)
+	testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+
+	// Hamcrest (matchesPattern 등으로 응답 검증 시)
+	testImplementation 'org.hamcrest:hamcrest:2.2'
+
+	// ✅ 테스트용 추가
+	testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+	testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/stepguide/backend/domain/accountTransfer/external/PortOneClient.java
+++ b/src/main/java/com/stepguide/backend/domain/accountTransfer/external/PortOneClient.java
@@ -1,69 +1,81 @@
 package com.stepguide.backend.domain.accountTransfer.external;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.HashMap;
+import java.time.Instant;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @Service
+@RequiredArgsConstructor
 public class PortOneClient {
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
-    // application.properties에서 가져오기
     @Value("${portone.imp.key}")
     private String impKey;
 
     @Value("${portone.imp.secret}")
     private String impSecret;
 
-    // 1) 토큰 발급
+    private static final String REDIS_TOKEN_KEY = "portone:access_token";
+
     public String getAccessToken() {
+        // 1. Redis에서 먼저 확인
+        Object cachedToken = redisTemplate.opsForValue().get(REDIS_TOKEN_KEY);
+        if (cachedToken instanceof String token && !token.isEmpty()) {
+            System.out.println("Redis 캐시 사용: " + token);
+            return token;
+        }
+
+        // 2. 없으면 실제 발급 요청
         String url = "https://api.iamport.kr/users/getToken";
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+        headers.setContentType(MediaType.APPLICATION_JSON);
 
-
-        Map<String, String> body = new HashMap<>();
-        body.put("imp_key", impKey);
-        body.put("imp_secret", impSecret);
-        System.out.println("body: " + body);
+        Map<String, String> body = Map.of(
+                "imp_key", impKey,
+                "imp_secret", impSecret
+        );
 
         HttpEntity<Map<String, String>> request = new HttpEntity<>(body, headers);
-        System.out.println("request: " + request);
         ResponseEntity<Map> response = restTemplate.postForEntity(url, request, Map.class);
-        System.out.println("response: " + response);
 
-//        ResponseEntity<Map> response = restTemplate.postForEntity(url, body, Map.class);
         Map<String, Object> responseBody = response.getBody();
-        System.out.println("responseBody: " + responseBody);
-
         if (responseBody == null || !responseBody.containsKey("response")) {
             throw new IllegalStateException("PortOne 토큰 발급 실패");
         }
 
         Map<String, Object> resp = (Map<String, Object>) responseBody.get("response");
+        String token = (String) resp.get("access_token");
+        long expireAt = ((Number) resp.get("expired_at")).longValue();
 
-        System.out.println("resp: " + resp);
-        return (String) resp.get("access_token");
+        long now = Instant.now().getEpochSecond();
+        long ttl = expireAt - now - 10; // 버퍼 10초
+
+        // 3. Redis에 저장
+        if (ttl > 0) {
+            redisTemplate.opsForValue().set(REDIS_TOKEN_KEY, token, ttl, TimeUnit.SECONDS);
+            System.out.println("Redis에 토큰 저장 완료 (TTL: " + ttl + "초)");
+        }
+
+        return token;
     }
 
-    // 2) 계좌 예금주 조회
     public String getAccountHolderName(String bankCode, String accountNumber) {
-        String accessToken = getAccessToken();  // 토큰 발급
+        String accessToken = getAccessToken();
 
         String url = String.format(
                 "https://api.iamport.kr/vbanks/holder?bank_code=%s&bank_num=%s",
                 bankCode, accountNumber
         );
-        System.out.println("요청  url = " + url);
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + accessToken);
@@ -71,22 +83,54 @@ public class PortOneClient {
         HttpEntity<Void> entity = new HttpEntity<>(headers);
         ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.GET, entity, Map.class);
 
-        // 응답 전체 로그
-        System.out.println("PortOne 응답 전체: " + response);
-
         Map<String, Object> responseBody = response.getBody();
-        System.out.println("PortOne 응답 바디: " + responseBody);
-
         if (responseBody == null || !responseBody.containsKey("response")) {
-            throw new IllegalArgumentException("계좌 조회 실패");
+            String errMsg = responseBody != null ? (String) responseBody.get("message") : "응답 없음";
+            throw new IllegalArgumentException("PortOne 실명조회 실패: " + errMsg);
         }
 
         Map<String, Object> resp = (Map<String, Object>) responseBody.get("response");
-
-        System.out.println("계좌 예금주 정보: " + resp);
-
-        return (String) resp.get("bank_holder");  // 예금주명 반환
-
+        return (String) resp.get("bank_holder"); //예금주명 반환
     }
 
+    /*
+    토큰 강제 제거 후 발급 테스트 시 사용
+     */
+    public String refreshAccessToken() {
+        // 1. 기존 토큰 제거
+        redisTemplate.delete("portone:access_token");
+
+        // 2. 새로 발급
+        String url = "https://api.iamport.kr/users/getToken";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> body = Map.of(
+                "imp_key", impKey,
+                "imp_secret", impSecret
+        );
+
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<Map> response = restTemplate.postForEntity(url, request, Map.class);
+
+        Map<String, Object> responseBody = response.getBody();
+        if (responseBody == null || !responseBody.containsKey("response")) {
+            throw new IllegalStateException("PortOne 토큰 재발급 실패");
+        }
+
+        Map<String, Object> resp = (Map<String, Object>) responseBody.get("response");
+        String token = (String) resp.get("access_token");
+        long expireAt = ((Number) resp.get("expired_at")).longValue();
+
+        long now = Instant.now().getEpochSecond();
+        long ttl = expireAt - now - 10;
+
+        if (ttl > 0) {
+            redisTemplate.opsForValue().set("portone:access_token", token, ttl, TimeUnit.SECONDS);
+            System.out.println("[refresh] Redis에 새 토큰 저장 (TTL: " + ttl + "s)");
+        }
+
+        return token;
+    }
 }

--- a/src/main/java/com/stepguide/backend/domain/accountTransfer/external/PortOneTestController.java
+++ b/src/main/java/com/stepguide/backend/domain/accountTransfer/external/PortOneTestController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/postonetest")
-public class PortOneTestContoller {
+public class PortOneTestController {
 
     private final PortOneClient portOneClient;
 

--- a/src/main/java/com/stepguide/backend/domain/coview/controller/CoViewController.java
+++ b/src/main/java/com/stepguide/backend/domain/coview/controller/CoViewController.java
@@ -1,8 +1,12 @@
 package com.stepguide.backend.domain.coview.controller;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stepguide.backend.domain.coview.dto.UserStateMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -11,11 +15,11 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 public class CoViewController {
 
-
     private final SimpMessagingTemplate messagingTemplate;
-
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     // 테스트용 ping/pong
     @MessageMapping("/ping")
@@ -23,13 +27,11 @@ public class CoViewController {
         messagingTemplate.convertAndSend("/topic/pong", "pong: " + msg);
     }
 
-
     // 사용자 → 보호자 : 현재 위치 상태
     @MessageMapping("/state/{code}")
     public void sendUserState(@DestinationVariable String code, @Payload UserStateMessage message) {
         messagingTemplate.convertAndSend("/topic/state/" + code, message);
     }
-
 
     // 사용자 → 보호자 : 강조 상태 정보
     @MessageMapping("/state/highlight/{code}")
@@ -37,10 +39,68 @@ public class CoViewController {
         messagingTemplate.convertAndSend("/topic/highlight/" + code, message);
     }
 
-
     // 보호자 → 사용자 메시지
     @MessageMapping("/message/{code}")
     public void sendGuardianMessage(@DestinationVariable String code, @Payload String msg) {
         messagingTemplate.convertAndSend("/topic/message/" + code, msg);
+    }
+
+    // WebRTC 시그널링 메시지 처리 (개선된 버전)
+    @MessageMapping("/webrtc/{code}")
+    public void handleWebRTCSignaling(@DestinationVariable String code, @Payload String message) {
+        try {
+            // 메시지 크기 로깅
+            log.info("WebRTC 시그널링 메시지 수신 - 코드: {}, 크기: {} bytes", code, message.length());
+
+            // JSON 파싱 검증
+            JsonNode messageNode = objectMapper.readTree(message);
+            String type = messageNode.get("type").asText();
+            JsonNode data = messageNode.get("data");
+
+            log.info("WebRTC 메시지 파싱 성공 - 타입: {}, 데이터 존재: {}", type, data != null);
+
+            // 메시지 크기가 너무 큰 경우 경고
+            if (message.length() > 32768) {
+                log.warn("WebRTC 메시지 크기가 큽니다: {} bytes (코드: {})", message.length(), code);
+            }
+
+            // WebRTC 시그널링 메시지를 그대로 브로드캐스트
+            messagingTemplate.convertAndSend("/topic/webrtc/" + code, message);
+
+            log.info("WebRTC 메시지 브로드캐스트 완료 - 코드: {}", code);
+
+        } catch (JsonProcessingException e) {
+            log.error("WebRTC 메시지 JSON 파싱 실패 - 코드: {}, 에러: {}", code, e.getMessage());
+            // 에러 메시지를 클라이언트에 전송
+            messagingTemplate.convertAndSend("/topic/webrtc/" + code,
+                    "{\"type\":\"error\",\"message\":\"JSON 파싱 실패: " + e.getMessage() + "\"}");
+        } catch (Exception e) {
+            log.error("WebRTC 메시지 처리 실패 - 코드: {}, 에러: {}", code, e.getMessage());
+            // 에러 메시지를 클라이언트에 전송
+            messagingTemplate.convertAndSend("/topic/webrtc/" + code,
+                    "{\"type\":\"error\",\"message\":\"메시지 처리 실패: " + e.getMessage() + "\"}");
+        }
+    }
+
+    // WebRTC 연결 상태 확인
+    @MessageMapping("/webrtc/status/{code}")
+    public void handleWebRTCStatus(@DestinationVariable String code, @Payload String status) {
+        try {
+            log.info("WebRTC 연결 상태 업데이트 - 코드: {}, 상태: {}", code, status);
+            messagingTemplate.convertAndSend("/topic/webrtc/status/" + code, status);
+        } catch (Exception e) {
+            log.error("WebRTC 상태 메시지 처리 실패 - 코드: {}, 에러: {}", code, e.getMessage());
+        }
+    }
+
+    // WebRTC 에러 처리
+    @MessageMapping("/webrtc/error/{code}")
+    public void handleWebRTCError(@DestinationVariable String code, @Payload String error) {
+        try {
+            log.error("WebRTC 에러 수신 - 코드: {}, 에러: {}", code, error);
+            messagingTemplate.convertAndSend("/topic/webrtc/error/" + code, error);
+        } catch (Exception e) {
+            log.error("WebRTC 에러 메시지 처리 실패 - 코드: {}, 에러: {}", code, e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/stepguide/backend/domain/coview/dto/UserStateMessage.java
+++ b/src/main/java/com/stepguide/backend/domain/coview/dto/UserStateMessage.java
@@ -12,4 +12,3 @@ public class UserStateMessage {
     private String highlightedArea;     // 예: "금액 입력 칸"
     private String userName;            // 예: "김영자님"
 }
-

--- a/src/main/java/com/stepguide/backend/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/stepguide/backend/domain/user/mapper/UserMapper.java
@@ -11,4 +11,6 @@ public interface UserMapper {
                                        @Param("providerId") String providerId);
 
     void insertUser(UserDTO user); // useGeneratedKeys는 XML에서 설정
+
+    String findUsernameById(@Param("userId") Long userId);
 }

--- a/src/main/java/com/stepguide/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/stepguide/backend/domain/user/service/UserService.java
@@ -69,4 +69,7 @@ public class UserService {
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
     }
+    public String getUsernameById(Long userId){
+        return userMapper.findUsernameById(userId);
+    }
 }

--- a/src/main/java/com/stepguide/backend/global/config/WebSocketConfig.java
+++ b/src/main/java/com/stepguide/backend/global/config/WebSocketConfig.java
@@ -5,6 +5,7 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -23,6 +24,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.enableSimpleBroker("/topic");
         registry.setApplicationDestinationPrefixes("/app");
     }
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+        // 메시지 크기 제한 설정 (64KB)
+        registration.setMessageSizeLimit(65536);
+        registration.setSendBufferSizeLimit(65536);
+        registration.setSendTimeLimit(20000);
+    }
+
 }
 
 

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -28,4 +28,9 @@
              #{providerId})
     </insert>
 
+    <select id="findUsernameById" resultType="String">
+        SELECT username
+        FROM users
+        WHERE user_id = #{userId}
+    </select>
 </mapper>

--- a/src/test/java/com/stepguide/backend/domain/accountTransfer/external/PortOneClientTest.java
+++ b/src/test/java/com/stepguide/backend/domain/accountTransfer/external/PortOneClientTest.java
@@ -1,0 +1,128 @@
+package com.stepguide.backend.domain.accountTransfer.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class PortOneClientTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock//실제 Redis 저장소 역할만 수행
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    @InjectMocks
+    private PortOneClient portOneClient;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        // 테스트용 비밀키 세팅
+        ReflectionTestUtils.setField(portOneClient, "impKey", "test-key");
+        ReflectionTestUtils.setField(portOneClient, "impSecret", "test-secret");
+    }
+
+    @Test
+    void 토큰이_없으면_API요청_후_Redis에_저장된다() {
+        // given
+        when(valueOperations.get("portone:access_token")).thenReturn(null);
+
+        String token = "mock-token";
+        long expireAt = Instant.now().getEpochSecond() + 1800;
+        Map<String, Object> resp = Map.of("access_token", token, "expired_at", expireAt);
+        Map<String, Object> body = Map.of("response", resp);
+        ResponseEntity<Map> response = new ResponseEntity<>(body, HttpStatus.OK);
+
+        when(restTemplate.postForEntity(anyString(), any(), eq(Map.class)))
+                .thenReturn(response);
+
+        // when
+        String result = portOneClient.getAccessToken();
+
+        // then
+        assertEquals(token, result);
+        verify(valueOperations).set(eq("portone:access_token"), eq(token), anyLong(), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    void 토큰이_Redis에_있으면_API요청없이_그대로_사용된다() {
+        // given
+        when(valueOperations.get("portone:access_token")).thenReturn("cached-token");
+
+        // when
+        String result = portOneClient.getAccessToken();
+
+        // then
+        assertEquals("cached-token", result);
+        verify(restTemplate, never()).postForEntity(anyString(), any(), eq(Map.class));
+    }
+
+    @Test
+    void 토큰이_만료되었으면_다시_발급되고_Redis에_저장된다() {
+        // given
+        when(valueOperations.get("portone:access_token")).thenReturn(null); // Redis에 없음
+
+        String newToken = "new-token";
+        long expireAt = Instant.now().getEpochSecond() + 60; // 1분 남은 만료
+        Map<String, Object> resp = Map.of("access_token", newToken, "expired_at", expireAt);
+        Map<String, Object> body = Map.of("response", resp);
+        ResponseEntity<Map> response = new ResponseEntity<>(body, HttpStatus.OK);
+
+        when(restTemplate.postForEntity(anyString(), any(), eq(Map.class)))
+                .thenReturn(response);
+
+        // when
+        String result = portOneClient.getAccessToken();
+
+        // then
+        assertEquals(newToken, result);
+        verify(valueOperations).set(eq("portone:access_token"), eq(newToken), anyLong(), eq(TimeUnit.SECONDS));
+    }
+    @Test
+    void refreshAccessToken_기존토큰삭제_새토큰발급_저장된다() {
+        String refreshedToken = "refreshed-token";
+        long expireAt = Instant.now().getEpochSecond() + 1200;
+        Map<String, Object> resp = Map.of("access_token", refreshedToken, "expired_at", expireAt);
+        Map<String, Object> body = Map.of("response", resp);
+        ResponseEntity<Map> response = new ResponseEntity<>(body, HttpStatus.OK);
+
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(response);
+
+        String result = portOneClient.refreshAccessToken();
+
+        assertEquals(refreshedToken, result);
+        verify(redisTemplate).delete("portone:access_token");
+        verify(valueOperations).set(eq("portone:access_token"), eq(refreshedToken), anyLong(), eq(TimeUnit.SECONDS));
+
+        //추가: 유효시간 TTL 확인 출력
+        long now = Instant.now().getEpochSecond();
+        long ttl = expireAt - now;
+        System.out.println("portone 토큰 TTL (초) = " + ttl);
+    }
+}

--- a/src/test/java/com/stepguide/backend/domain/coview/HelpCodeControllerTest.java
+++ b/src/test/java/com/stepguide/backend/domain/coview/HelpCodeControllerTest.java
@@ -1,0 +1,59 @@
+package com.stepguide.backend.domain.coview;
+
+import com.stepguide.backend.domain.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.matchesRegex;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class HelpCodeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    void generateHelpCode_redis에저장되는지확인() throws Exception {
+        // 1️⃣ 테스트용 유저 ID → DB에 존재하는 유저 ID로 설정
+        Long testUserId = 1L;
+
+        // 2️⃣ username 조회
+        String expectedUsername = userService.getUsernameById(testUserId);
+
+        // 3️⃣ API 호출: AuthorizationPrincipal → userId로 흘러감
+        String code = mockMvc.perform(post("/api/help-code/generate")
+                        .principal(() -> testUserId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(content().string(matchesRegex("\\d{6}")))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        // 4️⃣ Redis에 저장된 값 검증
+        String savedValue = redisTemplate.opsForValue().get(code);
+        assertThat(savedValue).isEqualTo(expectedUsername);
+
+        // 5️⃣ (선택) Redis 키 TTL 확인
+        Long ttl = redisTemplate.getExpire(code);
+        System.out.println("⏱ TTL (seconds): " + ttl);
+
+        // 6️⃣ Redis cleanup (선택적으로 삭제)
+        redisTemplate.delete(code);
+    }
+}


### PR DESCRIPTION
## ⚙️ PR 개요 (Backend)

어떤 기능을 추가/수정/리팩토링했는지 요약해주세요.

### 개요
- PortOne access token 발급 로직을 Redis 캐싱 기반으로 개선
- expired_at 캐스팅 오류(Long → Integer) 수정
- 간헐적으로 발생하던 500 에러를 해결

### 주요 변경 사항
- PortOneClient
  - access token Redis 저장/재사용 로직 추가
  - refreshAccessToken() 메서드 구현
  - expired_at 안전 캐스팅 (Number → longValue)
- 테스트 코드
  - 토큰 최초 저장/재사용/만료/refresh 테스트 추가

### 해결된 문제
- 매 요청마다 토큰 발급으로 인한 PortOne API 부하 및 500 에러 해결
- 캐싱 도입으로 API 호출 횟수 절감 및 안정성 향상
---

## 📌 주요 변경 내역

- [x] ⚙️ API 기능 추가
- [x] 🐛 버그 수정
- [ x 🧹 코드 정리 및 리팩토링
- [ ] 🗃️ DB 스키마 변경
- [ ] 🔒 보안 관련 수정

---

## 🔎 테스트 사항

- [x] Postman으로 API 테스트 완료
- [x] 정상적인 응답 및 예외 처리 확인


---

## 🧪 테스트 환경

- [x] Local


---

## 🧷 관련 이슈

> #14 

---

## 💬 리뷰어 참고 사항

- 쿼리 성능, 예외 처리, 논의가 필요한 로직이 있다면 여기에 작성해주세요.
